### PR TITLE
fix: github stats card not showing username

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 <p align="center" >
 <a href="https://github.com/anuraghazra/github-readme-stats"> 
-    <img  src="https://github-readme-stats.vercel.app/api?username=bornmay&&show_icons=true&theme=radical"/>
+    <img  src="https://github-readme-stats.vercel.app/api?username=bornmay&show_icons=true&theme=radical&custom_title=bornmay's%20Github%20Stats"/>
   </a>
 
 </p>


### PR DESCRIPTION
The github statistics card was previously showing `_'s Github Stats` without showing the username, this commit fixes it.